### PR TITLE
Various code improvements and fixes

### DIFF
--- a/ReverseKit/Hooks/CreateProcessInternalW.h
+++ b/ReverseKit/Hooks/CreateProcessInternalW.h
@@ -16,7 +16,7 @@ typedef BOOL(NTAPI* CreateProcessInternalW_t)(
 
 CreateProcessInternalW_t oCreateProcessInternalW;
 
-BOOL NTAPI hkCreateProcessInternalW(
+inline BOOL NTAPI hkCreateProcessInternalW(
     HANDLE hUserToken,
     LPCWSTR lpApplicationName,
     LPWSTR lpCommandLine,
@@ -33,13 +33,13 @@ BOOL NTAPI hkCreateProcessInternalW(
     InterceptedCallInfo Temp;
 
     Temp.functionName = "CreateProcessInternalW";
-    Temp.additionalInfo = ws2s(lpCommandLine).c_str();
+    Temp.additionalInfo = ws2s(lpCommandLine);
 
     interceptedCalls.push_back(Temp);
 
     ReverseHook::unhook(oCreateProcessInternalW, original_createprocess_bytes);
 
-    auto result = oCreateProcessInternalW(hUserToken, lpApplicationName, lpCommandLine, lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation, hNewToken);
+    const auto result = oCreateProcessInternalW(hUserToken, lpApplicationName, lpCommandLine, lpProcessAttributes, lpThreadAttributes, bInheritHandles, dwCreationFlags, lpEnvironment, lpCurrentDirectory, lpStartupInfo, lpProcessInformation, hNewToken);
 
     ReverseHook::hook(oCreateProcessInternalW, hkCreateProcessInternalW, original_createprocess_bytes);
 

--- a/ReverseKit/Hooks/InternetOpenUrlW.h
+++ b/ReverseKit/Hooks/InternetOpenUrlW.h
@@ -4,18 +4,18 @@ typedef HINTERNET(NTAPI* InternetOpenUrlW_t)(HINTERNET hInternet, LPCWSTR lpszUr
 
 InternetOpenUrlW_t oInternetOpenUrlW;
 
-HINTERNET NTAPI hkInternetOpenUrlW(HINTERNET hInternet, LPCWSTR lpszUrl, LPCWSTR lpszHeaders, DWORD dwHeadersLength, DWORD dwFlags, DWORD_PTR dwContext)
+inline HINTERNET NTAPI hkInternetOpenUrlW(HINTERNET hInternet, LPCWSTR lpszUrl, LPCWSTR lpszHeaders, DWORD dwHeadersLength, DWORD dwFlags, DWORD_PTR dwContext)
 {
     InterceptedCallInfo Temp;
 
     Temp.functionName = "InternetOpenUrlW";
-    Temp.additionalInfo = ws2s(lpszUrl).c_str();
+    Temp.additionalInfo = ws2s(lpszUrl);
 
     interceptedCalls.push_back(Temp);
 
     ReverseHook::unhook(oInternetOpenUrlW, original_openurl_bytes);
 
-    auto result = oInternetOpenUrlW(hInternet, lpszUrl, lpszHeaders, dwHeadersLength, dwFlags, dwContext);
+    const auto result = oInternetOpenUrlW(hInternet, lpszUrl, lpszHeaders, dwHeadersLength, dwFlags, dwContext);
 
     ReverseHook::hook(oInternetOpenUrlW, hkInternetOpenUrlW, original_openurl_bytes);
 

--- a/ReverseKit/ReverseKit.vcxproj.user
+++ b/ReverseKit/ReverseKit.vcxproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ShowAllFiles>true</ShowAllFiles>
+  </PropertyGroup>
+</Project>

--- a/ReverseKit/ReverseLib/ReverseHook.h
+++ b/ReverseKit/ReverseLib/ReverseHook.h
@@ -21,7 +21,7 @@ namespace ReverseHook {
         VirtualProtect(original_function, 14, oldProtect, &oldProtect);
     }
 
-    void unhook(void* original_function, unsigned char* original_bytes) {
+    void unhook(void* original_function, const unsigned char* original_bytes) {
         DWORD oldProtect;
 
         VirtualProtect(original_function, 14, PAGE_EXECUTE_READWRITE, &oldProtect);
@@ -53,11 +53,11 @@ namespace ReverseHook {
         }
 
         void hook(void* original_function, void* hooked_function, unsigned char* original_bytes) {
-            DWORD oldProtect;
+            DWORD oldProtect = 0;
 
             void* trampoline = createTrampoline(original_function);
 
-            if (trampoline == NULL) {
+            if (trampoline == nullptr) {
                 return;
             }
 
@@ -80,8 +80,8 @@ namespace ReverseHook {
             VirtualProtect(original_function, 14, oldProtect, &oldProtect);
         }
 
-        void unhook(void* original_function, unsigned char* original_bytes) {
-            DWORD oldProtect;
+        void unhook(void* original_function, const unsigned char* original_bytes) {
+            DWORD oldProtect = 0;
 
             VirtualProtect(original_function, 14, PAGE_EXECUTE_READWRITE, &oldProtect);
 

--- a/ReverseKit/Threads/Threads.h
+++ b/ReverseKit/Threads/Threads.h
@@ -13,11 +13,11 @@ struct ThreadInfo {
 std::vector<ThreadInfo> threadInfo;
 
 void GetThreadInformation() {
-    DWORD processID = GetCurrentProcessId();
+	const DWORD processID = GetCurrentProcessId();
     
     std::vector<ThreadInfo> updatedThreadInfo;
 
-    HANDLE hThreadSnap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+	const HANDLE hThreadSnap = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
     if (hThreadSnap == INVALID_HANDLE_VALUE) {
         return;
     }
@@ -35,7 +35,7 @@ void GetThreadInformation() {
             continue;
         }
 
-        HANDLE hThread = OpenThread(THREAD_QUERY_INFORMATION, FALSE, te32.th32ThreadID);
+        const HANDLE hThread = OpenThread(THREAD_QUERY_INFORMATION, FALSE, te32.th32ThreadID);
         if (hThread == NULL) {
             continue;
         }
@@ -46,11 +46,11 @@ void GetThreadInformation() {
             continue;
         }
 
-        ULONGLONG kernelTimeDiff = (kernelTime.dwHighDateTime << 32) | kernelTime.dwLowDateTime;
-        ULONGLONG userTimeDiff = (userTime.dwHighDateTime << 32) | userTime.dwLowDateTime;
-        ULONGLONG elapsedTime = kernelTimeDiff + userTimeDiff;
-        ULONGLONG systemTime = GetTickCount64() * 10000;  // Convert from milliseconds to 100-nanosecond intervals
-        DWORD cpuUsage = static_cast<DWORD>((elapsedTime * 100) / systemTime);
+        const ULONGLONG kernelTimeDiff = (((ULONGLONG)kernelTime.dwHighDateTime) << 32) | kernelTime.dwLowDateTime;
+        const ULONGLONG userTimeDiff = (((ULONGLONG)userTime.dwHighDateTime) << 32) | userTime.dwLowDateTime;
+        const ULONGLONG elapsedTime = kernelTimeDiff + userTimeDiff;
+        const ULONGLONG systemTime = GetTickCount64() * 10000;  // Convert from milliseconds to 100-nanosecond intervals
+        const DWORD cpuUsage = static_cast<DWORD>((elapsedTime * 100) / systemTime);
 
         auto it = std::find_if(threadInfo.begin(), threadInfo.end(), [&](const ThreadInfo& info) {
             return info.threadId == te32.th32ThreadID;

--- a/ReverseKitLoader/ReverseKitLoader.h
+++ b/ReverseKitLoader/ReverseKitLoader.h
@@ -19,7 +19,7 @@ public:
 		const HANDLE hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, ProcessID);
 		if (!hProcess)
 		{
-			printf("Error: OpenProcess() failed: %d", GetLastError());
+			printf("Error: OpenProcess() failed: %lu", GetLastError());
 			return false;
 		}
 
@@ -40,7 +40,7 @@ public:
 				WriteProcessMemory(hProcess, RemoteString, DllName, strlen(DllName), nullptr);
 				const HANDLE hThread = CreateRemoteThread(hProcess, nullptr, NULL, (LPTHREAD_START_ROUTINE)LoadLib, (LPVOID)RemoteString, NULL, nullptr);
 				if (!hThread)
-					printf("Error: CreateRemoteThread() failed: %d", GetLastError());
+					printf("Error: CreateRemoteThread() failed: %lu", GetLastError());
 			}
 		}
 

--- a/ReverseKitLoader/ReverseKitLoader.h
+++ b/ReverseKitLoader/ReverseKitLoader.h
@@ -16,7 +16,7 @@ public:
 		if (!ProcessID)
 			return false;
 
-		HANDLE hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, ProcessID);
+		const HANDLE hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, ProcessID);
 		if (!hProcess)
 		{
 			printf("Error: OpenProcess() failed: %d", GetLastError());
@@ -25,19 +25,22 @@ public:
 
 		char DllName[MAX_PATH];
 
-		GetFullPathNameA(DLLName, MAX_PATH, DllName, NULL);
+		GetFullPathNameA(DLLName, MAX_PATH, DllName, nullptr);
 
-		HMODULE hKernel32 = GetModuleHandleA("kernel32.dll");
+		const HMODULE hKernel32 = GetModuleHandleA("kernel32.dll");
 
 		if (hKernel32)
 		{
-			LPVOID LoadLib = (LPVOID)GetProcAddress(hKernel32, "LoadLibraryA");
+			const LPVOID LoadLib = (LPVOID)GetProcAddress(hKernel32, "LoadLibraryA");
 
-			LPVOID RemoteString = VirtualAllocEx(hProcess, NULL, strlen(DllName), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+			const LPVOID RemoteString = VirtualAllocEx(hProcess, nullptr, strlen(DllName), MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
 
-			if (RemoteString) {
-				WriteProcessMemory(hProcess, RemoteString, DllName, strlen(DllName), NULL);
-				CreateRemoteThread(hProcess, NULL, NULL, (LPTHREAD_START_ROUTINE)LoadLib, (LPVOID)RemoteString, NULL, NULL);
+			if (RemoteString)
+			{
+				WriteProcessMemory(hProcess, RemoteString, DllName, strlen(DllName), nullptr);
+				const HANDLE hThread = CreateRemoteThread(hProcess, nullptr, NULL, (LPTHREAD_START_ROUTINE)LoadLib, (LPVOID)RemoteString, NULL, nullptr);
+				if (!hThread)
+					printf("Error: CreateRemoteThread() failed: %d", GetLastError());
 			}
 		}
 
@@ -48,10 +51,10 @@ public:
 
 	static DWORD GetProcessID(const char* ProcName)
 	{
-		HANDLE thSnapShot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+		const HANDLE thSnapShot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
 		if (thSnapShot == INVALID_HANDLE_VALUE)
 		{
-			printf("Error: Unable to create toolhelp snapshot!");
+			printf("Error: Unable to create tool help snapshot!");
 			return 0;
 		}
 
@@ -61,7 +64,7 @@ public:
 		BOOL retval = Process32First(thSnapShot, &pe);
 		while (retval)
 		{
-			if (!strcmp(pe.szExeFile, ProcName))
+			if (!strcmp((const char*)pe.szExeFile, ProcName))
 			{
 				CloseHandle(thSnapShot);
 				return pe.th32ProcessID;


### PR DESCRIPTION
[ReverseKit]:

InstrumentationCallback.h:
- Added consts
- Replaced NULL with nullptr
- Added inline keyword to functions
- Changed SymbolLookupResult (line 160) to BOOL instead of BOOLEAN. Converting BOOL to BOOLEAN can lead to a loss of high-order bits. Non-zero value can become 'FALSE'

Threads.h:
- Added consts
- Added cast to kernelTimeDiff (line 49) and userTimeDiff (line 50) to prevent undefined behavior. When you shift a value by a number of bits that is equal to or greater than the width of the type of the value being shifted, the behavior is undefined

ReverseHook.h:
- Added consts
- Replaced NULL with nullptr
- in hook and unhook functions, oldProtect was uninitialized

CreateProcessInternalW.h:
- Added consts
- Reduced casting (line 36), improves performance
- Added inline keyword to functions

InternetOpenUrlW.h
- Added inline to functions
- Added consts
- Reduced casting (line 18), improves performance

[ReverseKitLoader]:

ReverseKitLoader.h:
- Added consts
- Replaced NULL with nullptr
- Fixed a typo 'tool help' instead of 'toolhelp'
- Fixed formatting in printf used %d but should be %lu
- Added cast in GetProcessID function
- Added error handling for when CreateRemoteThread fails, this also fixes a potential resource leak