### PR TITLE
Small optimizations, _wcsimp usage fix

### DIFF
--- a/ReverseKit/Hooks/SetHooks.cpp
+++ b/ReverseKit/Hooks/SetHooks.cpp
@@ -112,8 +112,8 @@ BOOL NTAPI SetHooks::hkCreateProcessInternalW(
 	Temp.additionalInfo = ws2s(lpCommandLine);
 
 	// Prevent program from unloading sysmon driver
-	if (_wcsicmp(lpCommandLine, L"unload SysmonDrv")
-		|| _wcsicmp(lpCommandLine, L"fltMC.exe unload SysmonDrv"))
+	if (!_wcsicmp(lpCommandLine, L"unload SysmonDrv")
+		|| !_wcsicmp(lpCommandLine, L"fltMC.exe unload SysmonDrv"))
 	{
 		Temp.additionalInfo += " (blocked)";
 		interceptedCalls.push_back(Temp);
@@ -121,7 +121,7 @@ BOOL NTAPI SetHooks::hkCreateProcessInternalW(
 	}
 
 	// Prevent program from clearing windows event logs
-	if (_wcsicmp(lpCommandLine, L"wevtutil cl Setup & wevtutil cl System & wevtutil cl Security & wevtutil cl Application & fsutil usn deletejournal /D %c:"))
+	if (!_wcsicmp(lpCommandLine, L"wevtutil cl Setup & wevtutil cl System & wevtutil cl Security & wevtutil cl Application & fsutil usn deletejournal /D %c:"))
 	{
 		Temp.additionalInfo += " (blocked)";
 		interceptedCalls.push_back(Temp);

--- a/ReverseKit/Instrumentation/InstrumentationCallback.cpp
+++ b/ReverseKit/Instrumentation/InstrumentationCallback.cpp
@@ -147,19 +147,15 @@ void InstrumentationCallback(PCONTEXT ctx)
                 DWORD64 Displacement;
                 const BOOL SymbolLookupResult = SymFromAddr(GetCurrentProcess(), ctx->Rip, &Displacement, SymbolInfo);
 
-                if (!SymbolLookupResult) {
+                if (!SymbolLookupResult || !SymbolInfo) {
                     free(SymbolBuffer);
                     RtlRestoreContext(ctx, nullptr);
                 }
 
                 const uintptr_t pFunction = Instrumentation::GetProcAddress((PVOID)pDllInfo->baseAddress, SymbolInfo->Name);
-                if (!pFunction) {
-                    free(SymbolBuffer); //TODO: V586 https://pvs-studio.com/en/docs/warnings/v586/ The 'free' function is called twice for deallocation of the same memory space.
-                    RtlRestoreContext(ctx, nullptr);
-                }
+				const ULONG_PTR ReturnAddress = *((ULONG_PTR*)(ctx->Rsp));
 
-                const ULONG_PTR ReturnAddress = *((ULONG_PTR*)(ctx->Rsp));
-                if (!ReturnAddress) {
+                if (!pFunction || !ReturnAddress) {
                     free(SymbolBuffer);
                     RtlRestoreContext(ctx, nullptr);
                 }

--- a/ReverseKit/Threads/Threads.cpp
+++ b/ReverseKit/Threads/Threads.cpp
@@ -59,5 +59,5 @@ void GetThreadInformation() {
 
 	CloseHandle(hThreadSnap);
 
-	threadInfo = updatedThreadInfo;
+	threadInfo = std::move(updatedThreadInfo);
 }

--- a/ReverseKit/Threads/Threads.h
+++ b/ReverseKit/Threads/Threads.h
@@ -7,7 +7,7 @@ struct ThreadInfo
     DWORD threadId;
     DWORD cpuUsage;
 
-    bool operator==(const ThreadInfo& other) const
+    bool operator==(const ThreadInfo other) const
 	{
         return threadId == other.threadId;
     }

--- a/ReverseKitLoader/ReverseKitLoader.vcxproj
+++ b/ReverseKitLoader/ReverseKitLoader.vcxproj
@@ -72,15 +72,19 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
[ReverseKit]
Thread.h:
- Fixed passing cheap-to-copy argument by reference

SetHooks.cpp:
- Fixed _wcsicmp usage

Thread.cpp:
- Optimized thread copying

InstrumentationCallback.cpp:
- Optimized free calls